### PR TITLE
filename extension for unique strings bugfix

### DIFF
--- a/src/TetraText.php
+++ b/src/TetraText.php
@@ -842,9 +842,14 @@ class TetraText {
 			$string = substr($string, 0, $config['charLimit']);
 
 		if ($config['filename'])
+		{
+			$extension = File::extension($string);
 			$string = str_replace('.'.File::extension($string), '', $string).$suffix.'.'.$extension;
+		}
 		else
+		{
 			$string .= $suffix;
+		}
 
 		$existingRecord->where($config['field'], $string);
 


### PR DESCRIPTION
Basically the $extension variable was hanging without being set. I just set it before its use.
